### PR TITLE
updates default templates to interpolate df headers

### DIFF
--- a/yolopandas/chains.py
+++ b/yolopandas/chains.py
@@ -12,6 +12,7 @@ DEFAULT_LLM = None
 # Default template, no memory
 TEMPLATE = """
 You are working with a pandas dataframe in Python. The name of the dataframe is `df`.
+The dataframe has the following columns: {df_columns}.
 
 You should execute code as commanded to either provide information to answer the question or to
 do the transformations required.
@@ -30,13 +31,14 @@ print(df.head())
 ```
 ```python"""
 
-PROMPT = PromptTemplate(template=TEMPLATE, input_variables=["query", "df_head"])
+PROMPT = PromptTemplate(template=TEMPLATE, input_variables=["query", "df_head", "df_columns"])
 
 
 # Template with memory
 # TODO: add result of expected code to memory; currently we only remember what code was run.
 TEMPLATE_WITH_MEMORY = """
 You are working with a pandas dataframe in Python. The name of the dataframe is `df`.
+The dataframe has the following columns: {df_columns}.
 
 You are interacting with a programmer. The programmer issues commands and you should translate
 them into Python code and execute them.
@@ -56,7 +58,7 @@ df.head()
 ```python
 """
 PROMPT_WITH_MEMORY = PromptTemplate(
-    template=TEMPLATE_WITH_MEMORY, input_variables=["chat_history", "query", "df_head"]
+    template=TEMPLATE_WITH_MEMORY, input_variables=["chat_history", "query", "df_head", "df_columns"]
 )
 
 

--- a/yolopandas/llm_accessor.py
+++ b/yolopandas/llm_accessor.py
@@ -31,7 +31,7 @@ class LLMAccessor:
     def query(self, query: str, yolo: bool = False) -> Any:
         """Query the dataframe."""
         df = self.df
-        df_columns = df.columns
+        df_columns = df.columns.tolist()
         inputs = {"query": query, "df_head": df.head(), "df_columns": df_columns, "stop": "```"}
         llm_response = self.chain.run(**inputs)
         eval_expression = False

--- a/yolopandas/llm_accessor.py
+++ b/yolopandas/llm_accessor.py
@@ -31,7 +31,8 @@ class LLMAccessor:
     def query(self, query: str, yolo: bool = False) -> Any:
         """Query the dataframe."""
         df = self.df
-        inputs = {"query": query, "df_head": df.head(), "stop": "```"}
+        df_columns = df.columns
+        inputs = {"query": query, "df_head": df.head(), "df_columns": df_columns, "stop": "```"}
         llm_response = self.chain.run(**inputs)
         eval_expression = False
         if not yolo:


### PR DESCRIPTION
This PR updates the default prompt templates by injecting the dataframe headers to prevent hallucinated column names in queries.

Tests are passing.